### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Borrowing Event Attributes
 --------------------------
 
 If your events each have a field, let's say "subject", and you'd like to
-insert each event's value for that field into every row of the corrisponding
+insert each event's value for that field into every row of the corresponding
 range under a column of the same name, you can "borrow" event attributes using
 borrow_attributes, like so:
 


### PR DESCRIPTION
@beOn, I've corrected a typographical error in the documentation of the [cili](https://github.com/beOn/cili) project. Specifically, I've changed corrispond to correspond. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
